### PR TITLE
GRANT-377 - format dates

### DIFF
--- a/client/components/form/ApplicationTable.tsx
+++ b/client/components/form/ApplicationTable.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link';
 import { ApplicationTableProps } from '../../constants/interfaces';
+import { formatDate } from 'utils';
 
 type Props = { applications: ApplicationTableProps[] };
 
@@ -50,7 +51,7 @@ const TableBody: React.FC<Props> = data => {
               <td className={tdStyles}>{row.totalEstimatedCost}</td>
               <td className={tdStyles}>{row.asks}</td>
               <td className={tdStyles}>{row.assignedTo ? row.assignedTo.displayName : ''}</td>
-              <td className={tdStyles}>{row.updatedAt}</td>
+              <td className={tdStyles}>{formatDate(row.updatedAt)}</td>
               <td className={tdStyles}>{row.status}</td>
             </tr>
           </Link>

--- a/client/helpers/render-elements.helpers.tsx
+++ b/client/helpers/render-elements.helpers.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import Image from 'next/image';
 import { Button } from '@components';
 import { API_ENDPOINT } from '../constants';
+import { formatDate } from 'utils';
 
 const NO_DATA_LABEL = '-';
 
@@ -170,7 +171,7 @@ const renderGeneralField = (e: any, data: any) => {
       <span className='font-bold'>{label}</span>
       <span key={e.key}>
         {(e.type === 'currency' || e.type === 'simplecurrencyadvanced') && 'CA$'}
-        {`${value || NO_DATA_LABEL}`}
+        {`${formatDate(value) || NO_DATA_LABEL}`}
       </span>
     </div>
   );
@@ -279,7 +280,7 @@ const renderUsageCountForm = (e: any, data: any) => {
                 key={formInfo[index].label + index}
                 className='bg-white border-b-2 even:bg-bcGrayInput border-gray-200'
               >
-                <td className={bodyTdStyles}>{ad[formInfo[0].key] || NO_DATA_LABEL}</td>
+                <td className={bodyTdStyles}>{formatDate(ad[formInfo[0].key]) || NO_DATA_LABEL}</td>
                 <td className={bodyTdStyles}>{ad[formInfo[1].key] || NO_DATA_LABEL}</td>
                 <td className={bodyTdStyles}>{ad[formInfo[2].key] || NO_DATA_LABEL}</td>
                 <td className={bodyTdStyles}>{ad[formInfo[3].key] || NO_DATA_LABEL}</td>

--- a/client/package.json
+++ b/client/package.json
@@ -17,6 +17,7 @@
     "@react-keycloak-fork/ssr": "4.0.3",
     "axios": "1.1.3",
     "classnames": "2.3.2",
+    "dayjs": "1.11.9",
     "formik": "2.2.9",
     "json-as-xlsx": "2.5.3",
     "keycloak-js": "19.0.3",

--- a/client/pages/applications/[id].tsx
+++ b/client/pages/applications/[id].tsx
@@ -19,6 +19,7 @@ import { ApplicationStatus } from '../../constants';
 // import { WorkshopReview } from '../../components/application/WorkshopReview';
 import Link from 'next/link';
 import React from 'react';
+import { formatDate } from 'utils';
 
 const ApplicationDetails: NextPage = () => {
   const { query } = useRouter();
@@ -107,7 +108,7 @@ const ApplicationDetails: NextPage = () => {
                   <p className='text-lg'>
                     {item.value === 'lastUpdatedBy'
                       ? details[item.value]?.displayName
-                      : details[item.value]}
+                      : formatDate(details[item.value])}
                   </p>
                 </div>
               );

--- a/client/utils/format-date.ts
+++ b/client/utils/format-date.ts
@@ -1,0 +1,23 @@
+import dayjs from 'dayjs';
+
+export const formatDate = (value: string) => {
+  if (!value) {
+    return;
+  }
+
+  // dayjs isValid accepts any numbers we send back as unix timestamps
+  // so it converts, population, currency etc.
+
+  // need to use regex to check for date strings
+  // ^ matches beginning of string
+  // \d{4} matches 4 digits (YYYY)
+  // \d{2} matches 2 digits (MM and DD)
+  // (.*) remaining sequence, needed to add to prevent exact match to YYYY-MM-DD
+  const isDate = /^\d{4}-\d{2}-\d{2}(.*)/.test(value);
+
+  if (!isDate) {
+    return value;
+  }
+
+  return dayjs(value).format('YYYY-MM-DD');
+};

--- a/client/utils/index.ts
+++ b/client/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './format-date';

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -1152,7 +1152,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dayjs@npm:^1.11.9":
+"dayjs@npm:1.11.9":
   version: 1.11.9
   resolution: "dayjs@npm:1.11.9"
   checksum: a4844d83dc87f921348bb9b1b93af851c51e6f71fa259604809cfe1b49d1230e6b0212dab44d1cb01994c096ad3a77ea1cf18fa55154da6efcc9d3610526ac38
@@ -3634,7 +3634,7 @@ __metadata:
     autoprefixer: ^10.4.7
     axios: 1.1.3
     classnames: 2.3.2
-    dayjs: ^1.11.9
+    dayjs: 1.11.9
     eslint: 8.27.0
     eslint-config-next: 13.0.3
     eslint-config-prettier: ^8.5.0

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -1152,6 +1152,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"dayjs@npm:^1.11.9":
+  version: 1.11.9
+  resolution: "dayjs@npm:1.11.9"
+  checksum: a4844d83dc87f921348bb9b1b93af851c51e6f71fa259604809cfe1b49d1230e6b0212dab44d1cb01994c096ad3a77ea1cf18fa55154da6efcc9d3610526ac38
+  languageName: node
+  linkType: hard
+
 "debug@npm:4, debug@npm:^4.1.0, debug@npm:^4.1.1, debug@npm:^4.3.2, debug@npm:^4.3.3, debug@npm:^4.3.4":
   version: 4.3.4
   resolution: "debug@npm:4.3.4"
@@ -3627,6 +3634,7 @@ __metadata:
     autoprefixer: ^10.4.7
     axios: 1.1.3
     classnames: 2.3.2
+    dayjs: ^1.11.9
     eslint: 8.27.0
     eslint-config-next: 13.0.3
     eslint-config-prettier: ^8.5.0


### PR DESCRIPTION
### Summary:

- add `dayjs` library
- create format date function to match `YYYY-MM-DD`

The definition of done for this story is that:
- [x] dates are formatted to match `YYYY-MM-DD` (ex. 2023-08-08)

### References:

- [GRANT-356](https://jira.th.gov.bc.ca/browse/GRANT-377)

### Screenshots:
![Screenshot 2023-08-23 at 10 17 42 AM](https://github.com/bcgov/BCAT/assets/99211385/f76c212f-ad3b-48d8-856f-2820711dd396)
![Screenshot 2023-08-23 at 10 17 17 AM](https://github.com/bcgov/BCAT/assets/99211385/59667b59-625b-4c8e-86e5-fe51a9df0a74)
![Screenshot 2023-08-23 at 10 17 04 AM](https://github.com/bcgov/BCAT/assets/99211385/b7304000-6c4c-4acd-b8d3-2fd4c3e248c7)
![Screenshot 2023-08-23 at 10 16 50 AM](https://github.com/bcgov/BCAT/assets/99211385/dd5168a0-b512-4067-a5f2-cfa1bb8c1572)


### Safety

- [x] lint;
- [x] prettier;
- [x] testing;
