### PR TITLE
GRANT-336 - application excel export functionality

### DIFF
--- a/api/src/score/ro/raw-data.ro.ts
+++ b/api/src/score/ro/raw-data.ro.ts
@@ -1,16 +1,17 @@
-import { findApplicationType } from '../../application/constants';
-import { ApplicationVsDetailsInfo } from '../../application/ro/application-score.ro';
-import { WorkshopScore } from '../workshop-score.entity';
+import { Application } from '@/application/application.entity';
 
 const roHeaders = {
   sheet: 'Raw Data',
   columns: [
+    { label: 'Confirmation ID', value: 'confirmationId' },
+    { label: 'Application Name', value: 'applicantName' },
     { label: 'Application Type', value: 'applicationType' },
     { label: 'Project Title', value: 'projectTitle' },
     { label: 'Estimated Project Cost', value: 'totalEstimatedCost' },
     { label: 'Raw Ask', value: 'asks' },
-    { label: 'Overall Score', value: 'finalScore' },
-    { label: 'Score Ratio', value: 'scoreRatio' },
+    { label: 'Assigned To', value: 'assignedTo' },
+    { label: 'Last Update', value: 'lastUpdated' },
+    { label: 'Status', value: 'status' },
   ],
 };
 
@@ -19,33 +20,35 @@ export interface RawData {
   columns: { label: string; value: string }[];
 
   content: {
+    confirmationId: string;
+    applicantName: string;
     applicationType: string;
     projectTitle: string;
     totalEstimatedCost: string;
     asks: string;
-    finalScore: number;
-    scoreRatio: string;
+    assignedTo: string;
+    lastUpdated: string;
+    status: string;
   }[];
 }
 
 export class RawDataRo {
   result: RawData[];
-  constructor(data: WorkshopScore[]) {
-    this.result = [{ ...roHeaders, ...this.convertWorkshopScoreToContent(data) }];
+  constructor(data: Application[]) {
+    this.result = [{ ...roHeaders, ...this.convertApplicationToContent(data) }];
   }
-  convertWorkshopScoreToContent(data: WorkshopScore[]) {
-    const content = data.map((item: WorkshopScore) => {
-      const applicationType = findApplicationType(item.application.form.chefsFormId);
-
+  convertApplicationToContent(data: Application[]) {
+    const content = data.map((item: Application) => {
       return {
-        applicationType: item.application.applicationType,
-        projectTitle: item.application.projectTitle,
-        totalEstimatedCost: item.application.totalEstimatedCost,
-        asks: item.application.asks,
-        finalScore: item.finalScore,
-        scoreRatio: `${(
-          item.finalScore / ApplicationVsDetailsInfo[applicationType].totalScore
-        ).toFixed(3)}`,
+        confirmationId: item.confirmationId,
+        applicantName: item.applicantName,
+        applicationType: item.applicationType,
+        projectTitle: item.projectTitle,
+        totalEstimatedCost: item.totalEstimatedCost,
+        asks: item.asks,
+        assignedTo: item?.assignedTo?.displayName || '-',
+        lastUpdated: item.updatedAt.toString(),
+        status: item.status,
       };
     });
     return { content };

--- a/api/src/score/workshop-score.service.ts
+++ b/api/src/score/workshop-score.service.ts
@@ -72,13 +72,4 @@ export class WorkshopScoreService {
       .andWhere('workshop.completionStatus = :status', { status: CompletionStatus.COMPLETE })
       .getOne();
   }
-
-  async getApplicationsWithFinalScores(): Promise<WorkshopScore[]> {
-    return this.workshopScoreRepository
-      .createQueryBuilder('workshop')
-      .innerJoinAndSelect('workshop.application', 'application')
-      .innerJoinAndSelect('application.form', 'form')
-      .andWhere('workshop.completionStatus = :status', { status: CompletionStatus.COMPLETE })
-      .getMany();
-  }
 }


### PR DESCRIPTION
### Pending:
- confirm column order and date format, commented in JIRA ticket

### Summary:

- add excel export functionality to Application table

The following columns should be present and populated:
- Confirmation ID
- Applicant Name 
- Application type (Infrastructure or Network)
- Project Title
- Estimated Cost 
- Asks
- Assigned to 
- Last Update
- Status

The statuses of applications that should be in the excel sheet are:
- Assigned
- Workshop

The definition of done for this story is that:
- [x] `Download Raw Data` button downloads an excel spreadsheet, summarizing applications in `assigned` or `workshop` status
- [x] All columns below should be present
- [x] All columns should be populated with application summary data
- [x] All data exported is correctly displayed
- [x] The user is able to download and view the data in an Excel sheet

### References:

- [GRANT-356](https://jira.th.gov.bc.ca/browse/GRANT-336)

### Screenshots:
![Screenshot 2023-08-23 at 2 03 15 PM](https://github.com/bcgov/BCAT/assets/99211385/649a3a13-206e-4dda-95ea-cc7c37495b4d)

### Safety

- [x] lint;
- [x] prettier;
- [x] testing;
