### PR TITLE
GRANT-390 - fix long string styling

### DIFF
--- a/client/helpers/render-elements.helpers.tsx
+++ b/client/helpers/render-elements.helpers.tsx
@@ -169,7 +169,7 @@ const renderGeneralField = (e: any, data: any) => {
   return (
     <div key={e.id} className='w-fit grid grid-flow-row'>
       <span className='font-bold'>{label}</span>
-      <span key={e.key}>
+      <span className='overflow-auto' key={e.key}>
         {(e.type === 'currency' || e.type === 'simplecurrencyadvanced') && 'CA$'}
         {`${formatDate(value) || NO_DATA_LABEL}`}
       </span>


### PR DESCRIPTION
### Summary:
-  long strings without whitespaces are overlapping components and ignoring styling
- no whitespaces means tailwind doesn't know when to break the word and wrap it

The definition of done for this story is that:
- [x] add overflow to longwinded strings
- [x] text WITH whitespaces are unaffected by this and will continue to wrap as normal

### References:

- [GRANT-390](https://jira.th.gov.bc.ca/browse/GRANT-390)

### Screenshots:

### Safety

- [x] lint;
- [x] prettier;
- [x] testing;
