### PR TITLE
GRANT-355 - fix infrastructure scoring

### DIFF
--- a/api/src/application/constants.ts
+++ b/api/src/application/constants.ts
@@ -86,10 +86,10 @@ export const InfrastructureScoreFields = [
     score: 15,
   },
   {
-    //safety score = 23, community and safety score = 15
+    //safety score = 23, community and safety score = 10
     name: 'safetyScore',
     label: 'Safety',
-    score: 38,
+    score: 33,
   },
   {
     name: 'economyAndTourismScore',

--- a/client/constants/review-constants.ts
+++ b/client/constants/review-constants.ts
@@ -32,6 +32,7 @@ export const INFRASTRUCTURE_REVIEW_QUESTIONS = [
       'Minimal physical barrier, minimal physical distancing, or minimal other/alternative approach = 2 pts (manual)',
       'Not physically separated = 0 pts (manual)',
       'Section 6. Question "The BC Active Transportation Design Guide recommends minimum widths for different types and contexts of active transportation infrastructure (see pg. 15 of the Program Guidelines). Does the proposed infrastructure align with the Design Guide recommendations?" - Only if Local context is selected = 0-4pts (manual)',
+      'Are there design features in place to minimize conflicts and ensure a safe transition for all intended users? = 2 pts for each design feature up to maximum of 5 pts (manual)',
     ],
     secondaryList: [
       'Section 6. Question "Identify which additional safety measures exist within the design of your project" = 1 pt each for each box ticked (ex: Lighting, Signage, etc) (auto)',
@@ -58,9 +59,9 @@ export const INFRASTRUCTURE_REVIEW_QUESTIONS = [
     maxScore: 8,
     label: 'Environment Score (manual)',
     descriptionList: [
-      'Environmental Benefits = 3 pts',
-      'Will the project retain existing Trees?  = 2 pts',
-      'Environmental Best Practices = 3 pts',
+      'Environmental Benefits = up to 3 pts',
+      'Will the project retain existing Trees? = up to 2 pts',
+      'Environmental Best Practices = up to 3 pts',
     ],
     tooltiptext:
       'Score on: GHG reductions, local measurements of GHG share from transportation, local sustainability plans for Environmental Benefits; Score on: local materials and labour, climate adaptation measures, dust mitigation, using recycled materials, drought-friendly plantings, using less toxic materials for Environmental Best Practices;',
@@ -70,7 +71,7 @@ export const INFRASTRUCTURE_REVIEW_QUESTIONS = [
     maxScore: 15,
     label: 'Land Use Score',
     descriptionList: [
-      'Does this project connect with other AT facilities = 2 pts (manual)',
+      'Does this project fill gaps between 2 or more AT Facilities = 2 pts (manual)',
       'Is this project a component of larger infrastructure project = 3 pts (manual)',
     ],
     secondaryList: [
@@ -85,8 +86,8 @@ export const INFRASTRUCTURE_REVIEW_QUESTIONS = [
     maxScore: 8,
     label: 'Accessibility Score (manual)',
     descriptionList: [
-      'Does this Project Incorporate Universal Design? = 5 pts',
-      'Does This Project Incorporate GBA+ Principles? = 3 pts',
+      'Does this Project Incorporate Universal Design? = up to 5 pts',
+      'Does This Project Incorporate GBA+ Principles? = up to 3 pts',
     ],
     tooltiptext:
       'Score on: curb cuts, grading, smooth surfaces, ramps, width, accessible washrooms, lighting, handrails, TWSIs, audible crossing signals, etc.; Score on: lighting, gender-neutral and family friendly washrooms, economically disadvantaged area, GBA+ training by project team, age-friendly design, rainbow crosswalks, signage in other languages, Indigenous land acknowledgements/ names on wayfinding signage, etc.;',
@@ -97,11 +98,13 @@ export const INFRASTRUCTURE_REVIEW_QUESTIONS = [
     label: 'Promotion Score (manual)',
     tooltiptext:
       'Score on promotional & educational activities = media event, signage, advertising, bike/ped maps, cycling courses, targeted outreach',
+    descriptionList: ['1 pt for each promotional feature listed, max 3'],
     name: 'promotionScore',
   },
   {
     maxScore: 3,
     label: 'Letters of Support (manual)',
+    descriptionList: ['1 pt for each letter of support, max 3'],
     name: 'lettersOfSupportScore',
   },
   {

--- a/client/constants/review-constants.ts
+++ b/client/constants/review-constants.ts
@@ -32,7 +32,7 @@ export const INFRASTRUCTURE_REVIEW_QUESTIONS = [
       'Minimal physical barrier, minimal physical distancing, or minimal other/alternative approach = 2 pts (manual)',
       'Not physically separated = 0 pts (manual)',
       'Section 6. Question "The BC Active Transportation Design Guide recommends minimum widths for different types and contexts of active transportation infrastructure (see pg. 15 of the Program Guidelines). Does the proposed infrastructure align with the Design Guide recommendations?" - Only if Local context is selected = 0-4pts (manual)',
-      'Are there design features in place to minimize conflicts and ensure a safe transition for all intended users? = 2 pts for each design feature up to maximum of 5 pts (manual)',
+      'Section 6. Question "When the project encounters or transitions to another facility type (e.g., a bike lane crossing an intersection, a multi-use path ending at a sidewalk), are there design features in place to minimize conflicts and ensure a safe transition for all intended users?" = 2 pts for each design feature listed, up to 5 pts (manual)',
     ],
     secondaryList: [
       'Section 6. Question "Identify which additional safety measures exist within the design of your project" = 1 pt each for each box ticked (ex: Lighting, Signage, etc) (auto)',

--- a/client/helpers/calculate-automated-scores.helpers.tsx
+++ b/client/helpers/calculate-automated-scores.helpers.tsx
@@ -65,22 +65,25 @@ const calculateLandUseScore = (s7Container: any) => {
   let score = 0;
 
   if (s7Container.s7ModesOfTransportation) {
-    score = Object.values(s7Container.s7ModesOfTransportation).filter(item => item).length;
-    if (score > 3) score = 3;
+    const transportationScore = Object.values(s7Container.s7ModesOfTransportation).filter(
+      item => item,
+    ).length;
+    transportationScore > 3 ? (score += 3) : (score += transportationScore);
   }
 
   if (s7Container.s7otherCommunityInfrastructure) {
-    score = Object.values(s7Container.s7otherCommunityInfrastructure).filter(item => item).length;
-    if (score > 4) score = 4;
+    const communityScore = Object.values(s7Container.s7otherCommunityInfrastructure).filter(
+      item => item,
+    ).length;
+    communityScore > 4 ? (score += 4) : (score += communityScore);
   }
 
   if (s7Container.s7activeTransportationInfrastructure) {
-    score = Object.values(s7Container.s7activeTransportationInfrastructure).filter(
-      item => item,
-    ).length;
-    if (score > 3) score = 3;
+    const activeTransportationScore = Object.values(
+      s7Container.s7activeTransportationInfrastructure,
+    ).filter(item => item).length;
+    activeTransportationScore > 3 ? (score += 3) : (score += activeTransportationScore);
   }
-
   return score;
 };
 


### PR DESCRIPTION
# Summary:
- change logic include all applications in excel spreadsheet

# Changes
- fix community safety score max from 15 to 10
- add question 36 is included in the scoring (logic is manual entry, 2 pts for each design feature to maximum of 5 pts). Safety Scoring should total 33 points after this update 
- Environment Score: Each bullet should read "up to" number of points
- Land Use Score: the first bullet should read "Does this project fill gaps between 2 or more AT Facilities = 2 pts (manual)"
- fix Land Use Score automated scoring 
- Accessibility Score: Each bullet should read "up to" number of points
- Promotion Score (manual) should have instruction bullet "1 pt for each promotional feature listed, max 3"
- Letters of Support: should have instruction bullet "1 pt for each letter of support, max 3"

# Ticket
https://jira.th.gov.bc.ca/browse/GRANT-355

# Safety:
- [x] lint;
- [x] test;
- [x] prettier;