### PR TITLE
GRANT-356 - fix network scoring

### DIFF
--- a/client/constants/review-constants.ts
+++ b/client/constants/review-constants.ts
@@ -166,14 +166,15 @@ export const NETWORK_REVIEW_QUESTIONS = [
       '1 point = $100-200',
       '0 points = >$200',
     ],
+    tooltiptext: 'Divide Total Estimated Project Cost by Community Population',
   },
   {
     maxScore: 4,
     label: 'Section 3. Components score (auto)',
     name: 's3ComponentsScore',
     secondaryList: [
-      `1 point each for a 'yes' answer to questions 3-5 (automated)`,
-      '1 point for at least 2 boxes checked on question 6. Up to 4 points total',
+      `1 point each for a 'yes' answer to questions 6-8 (automated)`,
+      '1 point for at least 2 boxes checked on question 9. Up to 4 points total',
     ],
     isAutomated: true,
     hiddenInput: true,
@@ -221,11 +222,7 @@ export const NETWORK_REVIEW_QUESTIONS = [
     maxScore: 5,
     label: 'Funding received over the last 5 years (manual)',
     name: 'fundingReceivedLastFiveYears',
-    descriptionList: [
-      'None = 5 pts',
-      'less than (<) $500,000 = 3 pts',
-      'more than (>) $500,000 = 0 pts',
-    ],
+    descriptionList: ['None = 5 pts', 'less than (<) $500,000 = 3 pts', '$500,000 or more = 0 pts'],
   },
 ];
 

--- a/client/helpers/review-questions.helpers.ts
+++ b/client/helpers/review-questions.helpers.ts
@@ -12,7 +12,7 @@ export const getComponentsScore = (data: any) => {
   let checkboxesSelected = 0;
 
   // check values for yes no questions
-  //Score 1 for each 'yes' answer to questions 3-5,
+  //Score 1 for each 'yes' answer to questions 6-8,
   S3_YES_NO_QUESTIONS.some((i: any) => {
     if (data[i] === 'yes') {
       score++;
@@ -20,7 +20,7 @@ export const getComponentsScore = (data: any) => {
   });
 
   // check value for checkboxes
-  // Score 1 for at least 2 boxes check on question 6, 0 for 1 or less selected
+  // Score 1 for at least 2 boxes check on question 9, 0 for 1 or less selected
   Object.values(data[S3_CHECKBOX_VALUES]).some((i: any) => {
     if (i && checkboxesSelected < 2) {
       checkboxesSelected++;


### PR DESCRIPTION
# Summary:
- update text changes to network scoring

# Changes
- Is this project a reasonable cost for the community size - Add instruction for question "Divide Total Estimated Project Cost by Community Population"
- Section 3 Components score, the bullets reference the old question numbers. Should reference questions 6-8 for a 'yes' answer and question 9 for at least two boxes checked. 
- Funding received over the last 5 years -  last bullet be updated to '$500,000 or more'

# Ticket
https://jira.th.gov.bc.ca/browse/GRANT-356

# Safety:
- [x] lint;
- [x] test;
- [x] prettier;