### PR TITLE
BCAT-542  | freeze table header

### DIFF
--- a/client/components/ScoreSummaryTable.tsx
+++ b/client/components/ScoreSummaryTable.tsx
@@ -22,7 +22,7 @@ const TableHeader: React.FC<TableHeaderProps> = ({ scores }) => {
   const tdStyles =
     'table-td table-header px-6 py-4 text-left text-sm font-strong border-b-2  border-bcYellowWarning';
   return (
-    <thead className='border-b bg-bcGrayInput table-header'>
+    <thead className='border-b bg-bcGrayInput table-header sticky top-0'>
       <tr>
         {headers &&
           headers.map((title: string, index: number) => (


### PR DESCRIPTION
- Goal: User found that when table getting bigger list, not able to see the header while scrolling.
Suggest: Freeze table header.

### before scroll
![CleanShot 2024-04-23 at 22 57 23@2x](https://github.com/bcgov/BCAT/assets/146475472/bc755b82-9af8-47ad-bb33-515bb6117923)

### after scroll with sticky header
![CleanShot 2024-04-23 at 22 58 04@2x](https://github.com/bcgov/BCAT/assets/146475472/4b6514f5-d867-4e7e-9bc0-2d3083651e52)
